### PR TITLE
 setting default blank favicon since there is none, fix #26

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -6,6 +6,7 @@
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" type="text/css" href="index.css" />
+    <link rel="icon" href="data:,">
   </head>
 
   <body>


### PR DESCRIPTION
setting a default blank favicon to fix this console error:

![image](https://user-images.githubusercontent.com/987947/188608918-4d3d01fc-e8c5-40d8-ba23-a63ac758e1d3.png)
